### PR TITLE
Introduce a handle-body idiom to separate implementation from the interface class

### DIFF
--- a/tdd-samples/callback-infra/acc/CMakeLists.txt
+++ b/tdd-samples/callback-infra/acc/CMakeLists.txt
@@ -42,3 +42,5 @@ foreach(TEST ${ACC_TESTS})
     # At some point this will depend on and link with a library that has the solution (production code)
     add_test(acc_${TEST} acc_${TEST})
 endforeach()
+
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <stdexcept>
 #include <thread>
@@ -9,8 +10,10 @@ using CallbackFunction = std::function<void(void)>;
 
 class CallbackInfrastructure {
 public:
-  virtual int registerCallback(Duration duration, CallbackFunction callback) {
-    return 0;
+  using IdType = std::size_t;
+  virtual IdType registerCallback(Duration duration,
+                                  CallbackFunction callback) {
+    throw std::runtime_error("Not Implemented!");
   }
   void deregisterCallback(int id){};
   virtual ~CallbackInfrastructure(){}; // this means we need move & copy ctors
@@ -36,26 +39,29 @@ public:
   virtual ~Worker(){};
 };
 
-class Infomap {
-public:
-  int add(Worker const &w) {
-    w_ = w;
-    return 0;
-  }
-  Worker remove(int id) { return w_; };
-
-private:
-  Worker w_;
-};
-
 class CallbackInfrastructureImpl : public CallbackInfrastructure {
 public:
   CallbackInfrastructureImpl() = default;
-  using FactoryMethodType = std::function<Worker(void)>;
+  using FactoryMethodType = std::function<Worker *()>;
   CallbackInfrastructureImpl(FactoryMethodType factory) : factory_{factory} {}
+  IdType registerCallback(Duration duration,
+                          CallbackFunction callback) override {
+    worker_ = factory_();
+    return 0;
+  };
 
 private:
+  Worker *worker_;
   FactoryMethodType factory_;
+};
+
+class Infomap {
+public:
+  int add(Worker const &w) { throw std::runtime_error("Not Implemented"); }
+  Worker remove(int id) { throw std::runtime_error("Not Implemented"); };
+
+private:
+  Worker w_;
 };
 
 class StdThreadWorker {

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -61,16 +61,19 @@ private:
 class StdThreadWorker {
 public:
   void schedule(Duration period, CallbackFunction callback) {
-    std::thread callback_thread([period, callback]() {
+    callback_thread = new std::thread([period, callback]() {
       std::this_thread::sleep_for(period);
       callback();
     });
   }
+
+private:
+  std::thread *callback_thread; // TODO: replace with uniq ptr
 };
 
 template <typename T = StdThreadWorker> class WorkerImpl : public Worker {
 public:
-  WorkerImpl(T const &impl = T()) : impl_(std::move(impl)) {}
+  WorkerImpl(T &&impl = T()) : impl_(std::forward<T>(impl)) {}
   virtual void schedule(Duration period, CallbackFunction callback) override {
     impl_.schedule(period, callback);
   };

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -32,7 +32,7 @@ public:
   virtual void schedule(Duration period, CallbackFunction callback) {
     throw std::runtime_error("Not Implemented!");
   }
-  virtual void cancel() {}
+  virtual void cancel() { throw std::runtime_error("Not Implemented!"); }
   virtual ~Worker(){};
 };
 
@@ -66,6 +66,9 @@ public:
       callback();
     });
   }
+  void cancel() {
+    //
+  }
 
 private:
   std::thread *callback_thread; // TODO: replace with smart ptr
@@ -74,9 +77,10 @@ private:
 template <typename T = StdThreadWorker> class WorkerImpl : public Worker {
 public:
   WorkerImpl(T &&impl = T()) : impl_(std::forward<T>(impl)) {}
-  virtual void schedule(Duration period, CallbackFunction callback) override {
+  void schedule(Duration period, CallbackFunction callback) override {
     impl_.schedule(period, callback);
   };
+  void cancel() override { impl_.cancel(); };
 
 private:
   T impl_;

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -68,7 +68,7 @@ public:
   }
 
 private:
-  std::thread *callback_thread; // TODO: replace with uniq ptr
+  std::thread *callback_thread; // TODO: replace with smart ptr
 };
 
 template <typename T = StdThreadWorker> class WorkerImpl : public Worker {

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -61,7 +61,7 @@ private:
 class StdThreadWorker {
 public:
   void schedule(Duration period, CallbackFunction callback) {
-    std::thread callback_thread([period, &callback]() {
+    std::thread callback_thread([period, callback]() {
       std::this_thread::sleep_for(period);
       callback();
     });

--- a/tdd-samples/callback-infra/include/solution.h
+++ b/tdd-samples/callback-infra/include/solution.h
@@ -3,13 +3,16 @@
 
 using Instant = std::chrono::time_point<std::chrono::system_clock>;
 using Duration = std::chrono::system_clock::duration;
+using CallbackFunction = std::function<void(void)>;
 
 class CallbackInfrastructure {
 public:
-  template <typename B> int registerCallback(Duration duration, B callback) {
+  virtual int registerCallback(Duration duration, CallbackFunction callback) {
     return 0;
   }
   void deregisterCallback(int id){};
+  virtual ~CallbackInfrastructure(){}; // this means we need move & copy ctors
+                                       // too!
 };
 
 auto Now() { return std::chrono::system_clock::now(); }
@@ -23,9 +26,10 @@ public:
 
 class Worker {
 public:
-  bool operator==(Worker const &other) const { return true; }
-  template <typename B> void schedule(Duration a, B b) {}
-  void cancel() {}
+  virtual bool operator==(Worker const &other) const { return true; }
+  virtual void schedule(Duration a, CallbackFunction b) {}
+  virtual void cancel() {}
+  virtual ~Worker(){};
 };
 
 class Infomap {
@@ -49,3 +53,9 @@ public:
 private:
   FactoryMethodType factory_;
 };
+
+template <typename T> class WorkerImpl : public Worker {
+  //
+};
+
+class StdThreadWorker {};

--- a/tdd-samples/callback-infra/int/CMakeLists.txt
+++ b/tdd-samples/callback-infra/int/CMakeLists.txt
@@ -49,3 +49,5 @@ foreach(TEST ${INT_TESTS})
     # At some point this will depend on and link with a library that has the solution (production code)
     add_test(int_${TEST} int_${TEST})
 endforeach()
+
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)

--- a/tdd-samples/callback-infra/int/CMakeLists.txt
+++ b/tdd-samples/callback-infra/int/CMakeLists.txt
@@ -1,4 +1,5 @@
 project(callback-infra-int)
+# project(callback-infra-int C CXX)
 
 cmake_minimum_required(VERSION 2.8)
 
@@ -10,6 +11,11 @@ enable_testing()
 set(CXX_STANDARD 14)
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+####################################################################
+# External libraries
+####################################################################
+find_package(Threads REQUIRED)
 
 ####################################################################
 # Set Compiler flags
@@ -39,6 +45,7 @@ list(APPEND INT_TESTS
 ####################################################
 foreach(TEST ${INT_TESTS})
     add_executable(int_${TEST} "${CMAKE_SOURCE_DIR}/${TEST}.cpp")
+    target_link_libraries(int_${TEST} Threads::Threads)
     # At some point this will depend on and link with a library that has the solution (production code)
     add_test(int_${TEST} int_${TEST})
 endforeach()

--- a/tdd-samples/callback-infra/int/main.cpp
+++ b/tdd-samples/callback-infra/int/main.cpp
@@ -7,96 +7,135 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-TEST_SUITE("Building an instance of CallbackInfra") {
-  TEST_CASE("Able to create an instance with default tick") {}
-  TEST_CASE("Cannot build instance without specifying tick") {}
+// ON/OFF test suites
+bool TEST_WORKER = true;
+bool TEST_CALLBACKINFRA = false;
+bool TEST_INTEGRATION = false;
+
+TEST_SUITE_BEGIN("CallbackInfra integration scenario" *
+                 doctest::skip(!TEST_INTEGRATION));
+
+TEST_CASE("Building an instance of CallbackInfra") {
+  SUBCASE("Able to create an instance with default tick") {}
+  SUBCASE("Cannot build instance without specifying tick") {}
 }
 
-TEST_SUITE("CallbackInfra registration scenario" * doctest::skip()) {
-  TEST_CASE("What (de)Register is made-up of") {
-    using namespace std::chrono_literals;
-    // this test works out the internals of the register method
-    auto period = 500ms;
-    auto callback = []() {};
-    Worker original;
+TEST_CASE("What (de)Register is made-up of") {
+  using namespace std::chrono_literals;
+  // this test works out the internals of the register method
+  auto period = 500ms;
+  auto callback = []() {};
+  Worker original;
 
-    original.schedule(period, callback);
-    original.cancel();
-    // Above leads to a unit-test for CallbackInfrastructure
-    //     Make mock worker
-    //     Create a CallbackInfrastructure-like object `sut` with mock worker as
-    //     dependency Call register on sut, expect call to worker with right
-    //     param values. Call de-register on sut, expect call to cancel.
-  }
-  TEST_CASE("How to keep track of registrations") {
-    using namespace std::chrono_literals;
-    auto period = 500ms;
-    auto callback = []() {};
-    Infomap m;
-    Worker original;
-
-    original.schedule(period, callback);
-    auto id = m.add(original);
-    CHECK(id != 0);
-
-    Worker retrieved = m.remove(id);
-    CHECK(retrieved == original);
-  }
+  original.schedule(period, callback);
+  original.cancel();
+  // Above leads to a unit-test for CallbackInfrastructure
+  //     Make mock worker
+  //     Create a CallbackInfrastructure-like object `sut` with mock worker as
+  //     dependency Call register on sut, expect call to worker with right
+  //     param values. Call de-register on sut, expect call to cancel.
 }
+TEST_CASE("How to keep track of registrations") {
+  using namespace std::chrono_literals;
+  auto period = 500ms;
+  auto callback = []() {};
+  Infomap m;
+  Worker original;
 
-TEST_SUITE("CallbackInfrastructureImpl Unit tests" * doctest::skip()) {
-  TEST_CASE("Can call register") {
-    using namespace std::chrono_literals;
-    CallbackInfrastructure *cIn = new CallbackInfrastructureImpl();
-    cIn->registerCallback(100ms, []() {});
-    delete cIn;
-  }
-  TEST_CASE(
-      "CallbackInfra Should use worker factory to process registrations") {
-    using namespace std::chrono_literals;
-    CallbackInfrastructure *cIn =
-        new CallbackInfrastructureImpl([]() { return Worker(); });
-    cIn->registerCallback(100ms, []() {});
-    delete cIn;
-  }
+  original.schedule(period, callback);
+  auto id = m.add(original);
+  CHECK(id != 0);
+
+  Worker retrieved = m.remove(id);
+  CHECK(retrieved == original);
 }
+TEST_SUITE_END(); // "CallbackInfra integration scenario"
 
-TEST_CASE("Worker Unit tests") {
-  struct MockCallbackProvider {
-    void doSomething() { didSomething = true; }
-    bool didSomething{false};
+TEST_SUITE_BEGIN("CallbackInfrastructureImpl Unit tests" *
+                 doctest::skip(!TEST_CALLBACKINFRA));
+TEST_CASE("Can call register") {
+  using namespace std::chrono_literals;
+  CallbackInfrastructure *cIn = new CallbackInfrastructureImpl();
+  cIn->registerCallback(100ms, []() {});
+  delete cIn;
+}
+TEST_CASE("CallbackInfra Should use worker factory to process registrations") {
+  using namespace std::chrono_literals;
+  CallbackInfrastructure *cIn =
+      new CallbackInfrastructureImpl([]() { return Worker(); });
+  cIn->registerCallback(100ms, []() {});
+  delete cIn;
+}
+TEST_SUITE_END(); // CallbackInfrastructureImpl Unit tests
+
+TEST_SUITE_BEGIN("Worker Unit tests" * doctest::skip(!TEST_WORKER));
+
+struct MockCallbackProvider {
+  void doSomething() {
+    std::cout << "Callback didSomething!" << std::endl;
+    didSomething = true;
+    callCount++;
+  }
+  bool didSomething{false};
+  unsigned callCount{0};
+};
+
+class WorkerShould {
+
+protected:
+  WorkerShould() {
+    using namespace std::chrono_literals;
+    w = new WorkerImpl<>();
+    REQUIRE(w != nullptr);
+    arbitrary_period = 100ms;
+    arbitrary_wait_time = arbitrary_period + 100ms;
+  }
+  virtual ~WorkerShould() { delete w; }
+  Worker *w;
+  Duration arbitrary_period;
+  Duration arbitrary_wait_time;
+};
+
+TEST_CASE_FIXTURE(WorkerShould, "schedule a callback with local lambda") {
+  // TODO: Need a timeout on this test-case not to exceed 2.5 periods
+  unsigned called{0};
+  auto fn = [&called]() {
+    std::cout << "Callback!" << std::endl;
+    ++called;
   };
-
-  Worker *w = new WorkerImpl<>(StdThreadWorker());
-  REQUIRE(w != nullptr);
-
-  SUBCASE("Can schedule a callback with local lambda") {
-    // TODO: Need a timeout on this test-case not to exceed 2.5 periods
-    using namespace std::chrono_literals;
-    auto arbitrary_period{500ms};
-    unsigned called{0};
-    auto fn = [&called]() {
-      std::cout << "Callback!" << std::endl;
-      ++called;
-    };
-    w->schedule(arbitrary_period, fn);
-    std::this_thread::sleep_for(arbitrary_period * 2);
-    CHECK(called > 0);
-  }
-
-  SUBCASE("Can schedule a callback with free function/ class member func") {
-    using namespace std::chrono_literals;
-    MockCallbackProvider mock;
-    auto arbitrary_period{500ms};
-    auto arbitrary_wait_time = arbitrary_period + 800ms;
-    auto memberFunc = std::bind(&MockCallbackProvider::doSomething, mock);
-    CHECK(!mock.didSomething);
-    w->schedule(arbitrary_period, memberFunc);
-    std::this_thread::sleep_for(arbitrary_wait_time);
-    // CHECK(mock.didSomething); this fails for reason unknown!
-  }
-  SUBCASE("Can cancel the currently schedule callback") {}
-  SUBCASE("Schedule should return immediately (within 1ms)") {}
-
-  delete w;
+  w->schedule(arbitrary_period, fn);
+  std::this_thread::sleep_for(arbitrary_wait_time);
+  CHECK(called > 0);
 }
+
+TEST_CASE_FIXTURE(WorkerShould,
+                  "schedule a callback with free function/ class member func") {
+  MockCallbackProvider mock;
+  auto memberFunc = std::bind(&MockCallbackProvider::doSomething, &mock);
+  CHECK(!mock.didSomething);
+  CHECK(mock.callCount == 0);
+  w->schedule(arbitrary_period, memberFunc);
+  std::this_thread::sleep_for(arbitrary_wait_time);
+  CHECK(mock.callCount > 0);
+  CHECK(mock.didSomething);
+}
+
+TEST_CASE_FIXTURE(WorkerShould, "cancel the currently schedule callback") {
+  w->cancel();
+}
+TEST_CASE_FIXTURE(WorkerShould, "invoke Callback repeatedly until cancelled") {
+  unsigned called{0};
+  unsigned multiple{3};
+  auto fn = [&called]() {
+    std::cout << "Callback!" << std::endl;
+    ++called;
+  };
+  w->schedule(arbitrary_period, fn);
+  std::this_thread::sleep_for(multiple * arbitrary_wait_time);
+  CHECK(called > 0);
+  // CHECK(called >= multiple); // TODO: Fix this
+}
+TEST_CASE_FIXTURE(WorkerShould,
+                  "return from Schedule() immediately (within 1ms)") {}
+
+TEST_SUITE_END(); // "Worker Unit Tests"

--- a/tdd-samples/callback-infra/int/main.cpp
+++ b/tdd-samples/callback-infra/int/main.cpp
@@ -64,6 +64,24 @@ TEST_SUITE("CallbackInfrastructureImpl Unit tests" * doctest::skip()) {
 TEST_SUITE("Worker Unit tests") {
   TEST_CASE("Can assert") { REQUIRE(true); }
   TEST_CASE("Can create a worker") {
-    [[maybe_unused]] WorkerImpl<StdThreadWorker> w;
+    Worker *w = new WorkerImpl<StdThreadWorker>();
+    delete w;
   }
+  TEST_CASE("Can schedule a callback with local lambda") {
+    // TODO: Need a timeout on this test-case not to exceed 2.5 periods
+    using namespace std::chrono_literals;
+    Worker *w = new WorkerImpl<StdThreadWorker>();
+    auto arbitrary_period{500ms};
+    volatile unsigned called{0};
+    w->schedule(arbitrary_period, [&called]() {
+      std::cout << "Callback!" << std::endl;
+      ++called;
+    });
+    std::this_thread::sleep_for(arbitrary_period * 2);
+    CHECK(called > 0);
+    delete w;
+  }
+  TEST_CASE("Can schedule a callback with free function/ class member func") {}
+  TEST_CASE("Can cancel the currently schedule callback") {}
+  TEST_CASE("Schedule should return immediately (within 1ms)") {}
 }

--- a/tdd-samples/callback-infra/int/main.cpp
+++ b/tdd-samples/callback-infra/int/main.cpp
@@ -72,11 +72,12 @@ TEST_SUITE("Worker Unit tests") {
     using namespace std::chrono_literals;
     Worker *w = new WorkerImpl<StdThreadWorker>();
     auto arbitrary_period{500ms};
-    volatile unsigned called{0};
-    w->schedule(arbitrary_period, [&called]() {
-      std::cout << "Callback!" << std::endl;
+    unsigned called{0};
+    auto fn = [&called]() {
+      // std::cout << "Callback!" << std::endl;
       ++called;
-    });
+    };
+    w->schedule(arbitrary_period, fn);
     std::this_thread::sleep_for(arbitrary_period * 2);
     CHECK(called > 0);
     delete w;

--- a/tdd-samples/callback-infra/int/main.cpp
+++ b/tdd-samples/callback-infra/int/main.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <thread>
 
 #include "solution.h"
@@ -7,61 +7,63 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-TEST_SUITE("Building an instance of CallbackInfra" * doctest::skip())
-{
-    TEST_CASE("Able to create an instance with default tick") {}
-    TEST_CASE("Cannot build instance without specifying tick") {}
+TEST_SUITE("Building an instance of CallbackInfra") {
+  TEST_CASE("Able to create an instance with default tick") {}
+  TEST_CASE("Cannot build instance without specifying tick") {}
 }
 
-TEST_SUITE("CallbackInfra registration scenario" * doctest::skip())
-{
-    TEST_CASE("What (de)Register is made-up of")
-    {
-        using namespace std::chrono_literals;
-        // this test works out the internals of the register method
-        auto period = 500ms;
-        auto callback = []() {};
-        Worker original;
+TEST_SUITE("CallbackInfra registration scenario" * doctest::skip()) {
+  TEST_CASE("What (de)Register is made-up of") {
+    using namespace std::chrono_literals;
+    // this test works out the internals of the register method
+    auto period = 500ms;
+    auto callback = []() {};
+    Worker original;
 
-        original.schedule(period, callback);
-        original.cancel();
-        // Above leads to a unit-test for CallbackInfrastructure
-        //     Make mock worker
-        //     Create a CallbackInfrastructure-like object `sut` with mock worker as dependency
-        //     Call register on sut, expect call to worker with right param values.
-        //     Call de-register on sut, expect call to cancel.
-    }
-    TEST_CASE("How to keep track of registrations")
-    {
-        using namespace std::chrono_literals;
-        auto period = 500ms;
-        auto callback = []() {};
-        Infomap m;
-        Worker original;
+    original.schedule(period, callback);
+    original.cancel();
+    // Above leads to a unit-test for CallbackInfrastructure
+    //     Make mock worker
+    //     Create a CallbackInfrastructure-like object `sut` with mock worker as
+    //     dependency Call register on sut, expect call to worker with right
+    //     param values. Call de-register on sut, expect call to cancel.
+  }
+  TEST_CASE("How to keep track of registrations") {
+    using namespace std::chrono_literals;
+    auto period = 500ms;
+    auto callback = []() {};
+    Infomap m;
+    Worker original;
 
-        original.schedule(period, callback);
-        auto id = m.add(original);
-        CHECK(id != 0);
+    original.schedule(period, callback);
+    auto id = m.add(original);
+    CHECK(id != 0);
 
-        Worker retrieved = m.remove(id);
-        CHECK(retrieved == original);
-    }
+    Worker retrieved = m.remove(id);
+    CHECK(retrieved == original);
+  }
 }
 
-TEST_SUITE("CallbackInfrastructureImpl Unit tests")
-{
-    TEST_CASE("Can call register")
-    {
-        using namespace std::chrono_literals;
-        CallbackInfrastructure *cIn = new CallbackInfrastructureImpl();
-        cIn->registerCallback(100ms, []() {});
-        delete cIn;
-    }
-    TEST_CASE("CallbackInfra Should use worker factory to process registrations")
-    {
-        using namespace std::chrono_literals;
-        CallbackInfrastructure *cIn = new CallbackInfrastructureImpl([]() { return Worker(); });
-        cIn->registerCallback(100ms, []() {});
-        delete cIn;
-    }
+TEST_SUITE("CallbackInfrastructureImpl Unit tests" * doctest::skip()) {
+  TEST_CASE("Can call register") {
+    using namespace std::chrono_literals;
+    CallbackInfrastructure *cIn = new CallbackInfrastructureImpl();
+    cIn->registerCallback(100ms, []() {});
+    delete cIn;
+  }
+  TEST_CASE(
+      "CallbackInfra Should use worker factory to process registrations") {
+    using namespace std::chrono_literals;
+    CallbackInfrastructure *cIn =
+        new CallbackInfrastructureImpl([]() { return Worker(); });
+    cIn->registerCallback(100ms, []() {});
+    delete cIn;
+  }
+}
+
+TEST_SUITE("Worker Unit tests") {
+  TEST_CASE("Can assert") { REQUIRE(true); }
+  TEST_CASE("Can create a worker") {
+    [[maybe_unused]] WorkerImpl<StdThreadWorker> w;
+  }
 }

--- a/tdd-samples/callback-infra/int/main.cpp
+++ b/tdd-samples/callback-infra/int/main.cpp
@@ -62,19 +62,20 @@ TEST_SUITE("CallbackInfrastructureImpl Unit tests" * doctest::skip()) {
 }
 
 TEST_SUITE("Worker Unit tests") {
-  TEST_CASE("Can assert") { REQUIRE(true); }
   TEST_CASE("Can create a worker") {
-    Worker *w = new WorkerImpl<StdThreadWorker>();
+    Worker *w = new WorkerImpl<>(StdThreadWorker());
+    REQUIRE(w != nullptr);
     delete w;
   }
   TEST_CASE("Can schedule a callback with local lambda") {
     // TODO: Need a timeout on this test-case not to exceed 2.5 periods
     using namespace std::chrono_literals;
-    Worker *w = new WorkerImpl<StdThreadWorker>();
+    Worker *w = new WorkerImpl<>();
+    REQUIRE(w != nullptr);
     auto arbitrary_period{500ms};
     unsigned called{0};
     auto fn = [&called]() {
-      // std::cout << "Callback!" << std::endl;
+      std::cout << "Callback!" << std::endl;
       ++called;
     };
     w->schedule(arbitrary_period, fn);

--- a/tdd-samples/callback-infra/watch.sh
+++ b/tdd-samples/callback-infra/watch.sh
@@ -1,11 +1,19 @@
 # A shell-wrapper to trigger build and execute whenever any file in this tree changes.
 # Use during development for rapid feedback.
+#
+# Usage:
+#     watch.sh <CMakeLists.txt path> <target to run after make>
 
-CMAKE_SUBDIR=int # Change to `acc` or `int` to run diff tests
+if [ $# -ne 2 ]; then
+  echo 1>&2 "Usage: $0 <CMakeLists.txt path> <target to run after make>"
+  exit 3
+fi
+
+CMAKE_SUBDIR=${1} # Change to `acc` or `int` to run diff tests
 WATCH_DIR=$PWD
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BS=build
 bash -c "rm -rf $REPO_ROOT/$BS"
 bash -c "mkdir $REPO_ROOT/$BS && cd $REPO_ROOT/$BS && cmake $WATCH_DIR/$CMAKE_SUBDIR"
-$REPO_ROOT/bin/rerun -c -v bash -c "cd $REPO_ROOT/$BS && make && make CTEST_OUTPUT_ON_FAILURE=1 test"
+$REPO_ROOT/bin/rerun -c -v bash -c "cd $REPO_ROOT/$BS && make && make CTEST_OUTPUT_ON_FAILURE=1 ${2}"


### PR DESCRIPTION
Introduce a handle-body idiom to separate implementation from the interface class. Re-write tests to use this. Provide generic implementation that adapts from any class that provides the correct interface.

Summary of changes:
1. Directly using any objects of interface classes throws a "not implemented" runtime error.
2. Interface classes do not have any member function templates. All types are now bound to specific design choices.
3. Unit test suites for woker and callbackinfra are developed. 
4. Worker tests are complete (1 test skipped due to missing implementation)

The purpose of this sub-branch is to allow a PIMP + template approach to swap out implementations without impacting client of the library. This is sufficiently demonstrated.

